### PR TITLE
Implement KYC check on claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```bash
 # configure app
-cleos push action claim.pomelo setconfig '{"config":["ok", "app.pomelo", "match.pomelo"]}' -p claim.pomelo
+cleos push action claim.pomelo setconfig '{"config":["ok", "login.eosn", "app.pomelo", "match.pomelo", ["shufti"], 180]}' -p claim.pomelo
 
 # transfer matching pool tokens from the vault
 cleos transfer match.pomelo claim.pomelo "1000.0000 EOS" "grant:grant1"
@@ -53,16 +53,22 @@ $ ./scripts/test.sh
 ## SINGLETON `config`
 
 - `{name} status` - contract status `ok`/`disabled`
-- `{name} pomelo_app` - Pomelo app account
-- `{name} pomelo_match` - Pomelo vault account
+- `{name} login_contract` - EOSN Login contract account (login.eosn)
+- `{name} pomelo_app` - Pomelo contract account (app.pomelo)
+- `{name} pomelo_match` - Pomelo vault account to receive and reclaim
+- `{set<name>} kyc_providers` - EOSN socials that are used for KYC
+- `{uint32_t} claim_period_days` - Claim expiry period in days
 
 ### example
 
 ```json
 {
-    "status": "ok",
-    "pomelo_app": "app.pomelo",
-    "pomelo_match": "match.pomelo"
+     "status": "ok",
+     "login_contract": "login.eosn",
+     "pomelo_app": "app.pomelo",
+     "pomelo_match": "match.pomelo",
+     "kyc_providers": ["shufti"],
+     "claim_period_days": 180
 }
 ```
 
@@ -81,6 +87,7 @@ $ ./scripts/test.sh
 ### params
 
 - `{name} project_id` - grant/bounty ID (primary key)
+- `{name} author_user_id` - grant author user id for KYC check
 - `{name} funding_account` - funding account eligible to claim
 - `{vector<extended_asset>} tokens` - claimable tokens
 - `{time_point_sec} created_at` - created at time
@@ -91,6 +98,7 @@ $ ./scripts/test.sh
 ```json
 {
     "project_id": "grant1",
+    "author_user_id": "prjman1.eosn",
     "funding_account": "prjman1",
     "tokens": ["1000.0000 EOS@eosio.token", "1000.0000 USDT@tethertether"],
     "created_at": "2021-12-06T00:00:00",
@@ -111,7 +119,7 @@ Set contract configuration
 ### example
 
 ```bash
-$ cleos push action claim.pomelo setconfig '{"config":["ok", "app.pomelo", "match.pomelo"]}' -p claim.pomelo
+$ cleos push action claim.pomelo setconfig '{"config":["ok", "login.eosn", "app.pomelo", "match.pomelo", ["shufti"], 180]}' -p claim.pomelo
 $ cleos push action claim.pomelo setconfig '{"config":null}' -p claim.pomelo
 ```
 
@@ -119,11 +127,11 @@ $ cleos push action claim.pomelo setconfig '{"config":null}' -p claim.pomelo
 
 - **authority**: `account`
 
-Claim funds
+Claim funds. Project author must pass KYC to be able to claim.
 
 ### params
 
-- `{name} account` - account making the claim
+- `{name} account` - EOS account making the claim
 - `{name} project_id` - project id of the project to claim funds for
 
 ### example

--- a/claim.pomelo.cpp
+++ b/claim.pomelo.cpp
@@ -1,6 +1,7 @@
 #include <eosio.token/eosio.token.hpp>
 #include <sx.utils/utils.hpp>
 #include <pomelo.app/app.pomelo.hpp>
+#include <eosn.login/login.eosn.hpp>
 
 #include "claim.pomelo.hpp"
 
@@ -36,6 +37,8 @@ void claimpomelo::claim( const name account, const name project_id )
     claims_table claims( get_self(), get_self().value );
     const auto& claim = claims.get( project_id.value, "claim.pomelo::claim: nothing to claim");
     check( claim.funding_account == account, "claim.pomelo::claim: invalid claiming account");
+
+    check_kyc( claim.author_user_id );
 
     vector<asset> claimed;
     for(const auto token: claim.tokens){
@@ -102,29 +105,48 @@ void claimpomelo::on_transfer( const name from, const name to, const asset quant
 
     check(project_id.value, "claim.pomelo::on_transfer: invalid project id");
 
-    name funding_account;
+    name funding_account, author_user_id;
     if (project_type == "grant"_n) {
         pomelo::grants_table grants( config.pomelo_app, config.pomelo_app.value );
-        funding_account = grants.get(project_id.value, "claim.pomelo::on_transfer: grant not found").funding_account;
+        const auto& grant = grants.get(project_id.value, "claim.pomelo::on_transfer: grant not found");
+        funding_account = grant.funding_account;
+        author_user_id = grant.author_user_id;
     }
     else if (project_type == "bounty"_n) {
         pomelo::bounties_table bounties( config.pomelo_app, config.pomelo_app.value );
-        funding_account = bounties.get(project_id.value, "claim.pomelo::on_transfer: bounty not found").funding_account;
+        const auto& bounty = bounties.get(project_id.value, "claim.pomelo::on_transfer: bounty not found");
+        funding_account = bounty.funding_account;
+        author_user_id = bounty.author_user_id;
     }
     else check( false, CLAIM_INVALID_MEMO);
 
     check( funding_account.value, "claim.pomelo::on_transfer: empty funding account");
 
-    add_tokens(project_id, funding_account, extended_asset{ quantity, get_first_receiver()}, config.claim_period_days);
+    add_tokens(project_id, author_user_id, funding_account, extended_asset{ quantity, get_first_receiver()}, config.claim_period_days);
 }
 
+void claimpomelo::check_kyc( const name author_user_id )
+{
+    config_table _config(get_self(), get_self().value);
+    const auto& config = _config.get();
 
-void claimpomelo::add_tokens( const name project_id, const name funding_account, const extended_asset ext_quantity, const uint64_t claim_period_days)
+    eosn::login::users_table _users( config.login_contract, config.login_contract.value );
+    const auto& user = _users.get( author_user_id.value, "claim.pomelo::check_kyc: [author_user_id] not found");
+
+    for( const auto& kyc: config.kyc_providers ) {
+        if( user.socials.count(kyc) ) return;
+    }
+
+    check( false, "claim.pomelo::check_kyc: project [author_user_id] needs to pass KYC first" );
+}
+
+void claimpomelo::add_tokens( const name project_id, const name author_user_id, const name funding_account, const extended_asset ext_quantity, const uint64_t claim_period_days)
 {
     claims_table claims( get_self(), get_self().value );
 
     const auto modify = [&]( auto& row ) {
         row.funding_account = funding_account;
+        row.author_user_id = author_user_id;
         row.project_id = project_id;
         if( !row.created_at.sec_since_epoch()) row.created_at = current_time_point();
         row.expires_at = time_point_sec(current_time_point().sec_since_epoch() + claim_period_days * 24 * 60 * 60);

--- a/claim.pomelo.cpp
+++ b/claim.pomelo.cpp
@@ -105,24 +105,20 @@ void claimpomelo::on_transfer( const name from, const name to, const asset quant
 
     check(project_id.value, "claim.pomelo::on_transfer: invalid project id");
 
-    name funding_account, author_user_id;
+    pomelo::projects_row project;
     if (project_type == "grant"_n) {
         pomelo::grants_table grants( config.pomelo_app, config.pomelo_app.value );
-        const auto& grant = grants.get(project_id.value, "claim.pomelo::on_transfer: grant not found");
-        funding_account = grant.funding_account;
-        author_user_id = grant.author_user_id;
+        project = grants.get(project_id.value, "claim.pomelo::on_transfer: grant not found");
     }
     else if (project_type == "bounty"_n) {
         pomelo::bounties_table bounties( config.pomelo_app, config.pomelo_app.value );
-        const auto& bounty = bounties.get(project_id.value, "claim.pomelo::on_transfer: bounty not found");
-        funding_account = bounty.funding_account;
-        author_user_id = bounty.author_user_id;
+        project = bounties.get(project_id.value, "claim.pomelo::on_transfer: bounty not found");
     }
     else check( false, CLAIM_INVALID_MEMO);
 
-    check( funding_account.value, "claim.pomelo::on_transfer: empty funding account");
+    check( project.funding_account.value, "claim.pomelo::on_transfer: empty funding account");
 
-    add_tokens(project_id, author_user_id, funding_account, extended_asset{ quantity, get_first_receiver()}, config.claim_period_days);
+    add_tokens(project_id, project.author_user_id, project.funding_account, extended_asset{ quantity, get_first_receiver()}, config.claim_period_days);
 }
 
 void claimpomelo::check_kyc( const name author_user_id )

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,7 @@ cleos push action app.pomelo token '["4,USDT", "tethertether", 10000, 0]' -p app
 # create and link eosn acc
 cleos push action login.eosn create '["prjman1.eosn", ["EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"]]' -p login.eosn
 cleos push action login.eosn link '["prjman1.eosn", "prjman1", "SIG_K1_KjnbJ2m22HtuRW7u7ZLdoCx76aNMiADHJpATGh32uYeJLdSjhdpHA7tmd4pj1Ni3mSr5DPRHHaydpaggrb5RcBg2HDDn7G"]' -p prjman1
+cleos push action login.eosn configsocial '["shufti", 5000]' -p login.eosn
 
 # create matching round and start it
 cleos push action app.pomelo setconfig '[0, 500, 500, "login.eosn", "fee.pomelo"]' -p app.pomelo
@@ -26,38 +27,46 @@ cleos push action app.pomelo setstate '["grant2", "published"]' -p app.pomelo
 cleos push action app.pomelo joinround '["grant2", 101]' -p app.pomelo -p prjman1.eosn
 
 # set claim config
-echo "Set config ✔️"
-cleos push action claim.pomelo setconfig '{"config":["ok", "app.pomelo", "match.pomelo", 180]}' -p claim.pomelo
+echo "Set config ✅"
+cleos push action claim.pomelo setconfig '{"config":["ok", "login.eosn", "app.pomelo", "match.pomelo", ["shufti"], 180]}' -p claim.pomelo
 
 # transfer funds from the vault
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 cleos transfer match.pomelo claim.pomelo "900.0000 EOS" "grant:grant1"
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 cleos transfer match.pomelo claim.pomelo "100.0000 EOS" "grant:grant1"
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 cleos transfer match.pomelo claim.pomelo "1000.0000 USDT" "grant:grant1" --contract tethertether
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 cleos transfer match.pomelo claim.pomelo "100.0000 EOS" "grant:grant2"
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 
-# claim funds
-echo "Claim funds for grant2 ✔️"
+# claim funds without KYC - must fail
+echo "Claim funds without KYC - must fail ❌"
 cleos push action claim.pomelo claim '[prjman1, grant1]' -p prjman1
-echo "Claim funds for grant2 ✔️"
+
+# set KYC social
+echo "Pass KYC ✅"
+cleos push action login.eosn social '[prjman1.eosn, shufti]' -p prjman1.eosn
+
+# claim funds with KYC
+echo "Claim funds for grant2 ✅"
+cleos push action claim.pomelo claim '[prjman1, grant1]' -p prjman1
+echo "Claim funds for grant2 ✅"
 cleos push action claim.pomelo claim '[prjman1, grant2]' -p prjman1
 
 # sleep to avoid duplicate trx
 sleep 1
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 # transfer funds from the vault
 cleos transfer match.pomelo claim.pomelo "1000.0000 EOS" "grant:grant1"
-echo "Transfer funds from the vault ✔️"
+echo "Transfer funds from the vault ✅"
 cleos transfer match.pomelo claim.pomelo "1000.0000 USDT" "grant:grant1" --contract tethertether
 
 # reclaim funds - must fail
-echo "Reclaim funds with wrong authority ❌"
+echo "Reclaim funds with wrong authority - must fail ❌"
 cleos push action claim.pomelo reclaim '[grant1]' -p prjman1
 
 # reclaim funds
-echo "Reclaim funds back to the vault ✔️"
+echo "Reclaim funds back to the vault ✅"
 cleos push action claim.pomelo reclaim '[grant1]' -p match.pomelo


### PR DESCRIPTION
- add `kyc_providers` vector to `config` table that contains a list of eosn.login socials that are used for KYC (i.e. "shufti")
- verify in `claim` action that grant author passed at least one of the configured KYC
- update readme